### PR TITLE
Add more configuration options and docker-compose examples 

### DIFF
--- a/docs/docs/Installation/Docker/Debian.md
+++ b/docs/docs/Installation/Docker/Debian.md
@@ -14,3 +14,5 @@ docker volume create fts_data
 
 docker run -d -p 8080:8080/tcp -p 8087:8087/tcp -e FTS_CONNECTION_MESSAGE="Server Connection Message" -e FTS_SAVE_COT_TO_DB="True" -v fts_data:/host/system/folder --name fts --restart unless-stopped freetakteam/freetakserver:1.1.2
 ```
+
+Alternatively, you can use the example `docker-compose.yml` [available here](https://github.com/FreeTAKTeam/FreeTAKServer-Docker/blob/main/docker-compose.yml) by copying `docker-compose.yml` into a directory and then doing `docker-compose up` or `docker-compose up -d` to bring the container up, and in the background, respectively. The `docker-compose.yml` uses a bind mount to `./data`.

--- a/docs/docs/Installation/Docker/Quick Start Guide.md
+++ b/docs/docs/Installation/Docker/Quick Start Guide.md
@@ -11,4 +11,7 @@ docker volume create fts_data
 
 docker run -d -p 8080:8080/tcp -p 8087:8087/tcp -e FTS_CONNECTION_MESSAGE="Server Connection Message" -e FTS_SAVE_COT_TO_DB="True" -v fts_data:/host/system/folder --name fts --restart unless-stopped freetakteam/freetakserver:1.1.2
 ```
+
 It is also possible to use an absolute path with a blind mount on the host instead of a proper volume.  For more information about volumes [https://docs.docker.com/storage/volumes/](https://docs.docker.com/storage/volumes/)
+
+Alternatively, you can use the example `docker-compose.yml` [available here](https://github.com/FreeTAKTeam/FreeTAKServer-Docker/blob/main/docker-compose.yml) by copying `docker-compose.yml` into a directory and then doing `docker-compose up` or `docker-compose up -d` to bring the container up, and in the background, respectively. The `docker-compose.yml` uses a bind mount to `./data`.

--- a/docs/docs/Installation/Docker/Raspberry Pi.md
+++ b/docs/docs/Installation/Docker/Raspberry Pi.md
@@ -18,5 +18,7 @@ docker volume create fts_data
 docker run -d -p 8080:8080/tcp -p 8087:8087/tcp -e FTS_CONNECTION_MESSAGE="Server Connection Message" -e FTS_SAVE_COT_TO_DB="True" -v fts_data:/host/system/folder --name fts --restart unless-stopped freetakteam/freetakserver:1.1.2
 ```
 
+Alternatively, you can use the example `docker-compose.yml` [available here](https://github.com/FreeTAKTeam/FreeTAKServer-Docker/blob/main/docker-compose.yml) by copying `docker-compose.yml` into a directory and then doing `docker-compose up` or `docker-compose up -d` to bring the container up, and in the background, respectively. The `docker-compose.yml` uses a bind mount to `./data`.
+
 # Older Pi's
 Raspberry Pi's prior to the Pi3 have not been tested, and would not be recommended for use.

--- a/docs/docs/Installation/Docker/Upgrade/Upgrade.md
+++ b/docs/docs/Installation/Docker/Upgrade/Upgrade.md
@@ -6,3 +6,12 @@ docker stop fts
 docker rm fts
 docker run -d -p 8080:8080/tcp -p 8087:8087/tcp -e FTS_CONNECTION_MESSAGE="Server Connection Message" -e FTS_SAVE_COT_TO_DB="True" -v fts_data:/data --name fts --restart unless-stopped freetakteam/freetakserver:{New FTS version}
 ```
+
+If using the `docker-compose.yml` file, perform the following:
+
+```bash
+docker-compose pull
+docker-compose down
+docker-compose up
+# alternatively, use docker-compose up -d to run in the background
+```

--- a/docs/docs/Installation/Docker/index.md
+++ b/docs/docs/Installation/Docker/index.md
@@ -8,17 +8,24 @@ When using this docker container we suggested that you use the `--restart unless
 ```bash
 docker volume create fts_data
 
-docker run -d -p 8080:8080/tcp -p 8087:8087/tcp -e FTS_CONNECTION_MESSAGE="Server Connection Message" -e FTS_SAVE_COT_TO_DB="True" -v fts_data:/data --name fts --restart unless-stopped freetakteam/freetakserver:1.1.2
+docker run -d -p 8080:8080/tcp -p 8087:8087/tcp -e FTS_CONNECTION_MESSAGE="Server Connection Message" -e FTS_COT_TO_DB="True" -v fts_data:/data --name fts --restart unless-stopped freetakteam/freetakserver:1.1.2
 ```
+
+Alternatively, you can use the example `docker-compose.yml` [available here](https://github.com/FreeTAKTeam/FreeTAKServer-Docker/blob/main/docker-compose.yml) by copying `docker-compose.yml` into a directory and then doing `docker-compose up` or `docker-compose up -d` to bring the container up, and in the background, respectively. The `docker-compose.yml` uses a bind mount to `./data`.
 
 ### Ports
 The docker image runs the ports on the same defaults as FreeTAKServer.  You can use the `-e` flag to map these ports to different ports or to run multiple FreeTAKServer's concurrently on the same host.
 
-### Environment Variabls
+### Environment Variables
+All environment variables will apply to FTS. However, these are some additional ones specific to this docker image.
 ```
-FTS_CONNECTION_MESSAGE: Accepts a string to send to users when they connect.  Set to "None" to disable.
-FTS_SAVE_COT_TO_DB: Accepts "True" or "False" setting to save CoTs to the DB.
-FTS_ARGS: Arguments to pass on the command line, "-AutoStart True" is passed automatically.  
+APPPORT: Allows hosting FTS UI from a different port, if needed
+APIIP: Allows the FTS UI to specify a different API port, if needed. Will use the `IP` environment variable, if not specified
+APIPORT: Allows the FTS UI to specify a different API port, if needed
+APIPROTOCOL: Allows the FTS UI to specify a different API protocol, if needed
+WEBMAPIP: Allows the FTS UI to specify a different webmap IP, if needed
+WEBMAPPORT: Allows the FTS UI to specify a different webmap port, if needed
+WEBMAPPROTOCOL: Allows the FTS UI to specify a different webmap protocol, if needed
 ```
 
 ### Storage
@@ -40,6 +47,7 @@ root@fts:/home/ubuntu# docker inspect fts_data
 ]
 ```
 
+The `docker-compose.yml` example utilizes a bind mount to `./data` in the same directory.
 
 ## Additional Architectures
 Currently the container is being cross compiled for `linux/amd64`,  `linux/arm64` and `linux/arm/v7`.  If additional processor architectures are needed please open an issue and request a new one.


### PR DESCRIPTION
## Changes
- Adds docker compose examples from linked FreeTAKServer-Docker PR to the documentation
- Adds additional environment variables from linked FreeTAKServer-UI and FreeTAKServer-Docker PRs

## Related PRs
- Linked PR for [FreeTAKServer-UI](https://github.com/FreeTAKTeam/UI/pull/19) introducing more configuration options
- Linked PR for [FreeTAKServer-Docker](https://github.com/FreeTAKTeam/FreeTAKServer-Docker/pull/29) for these new variables

This PR is mostly to document the new proposed environment variables for the UI and Docker containers. Please don't hesitate to give feedback or commentary on these changes. Thank you!