### PR TITLE
Navigation revamp

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocs-awesome-pages-plugin \
-                mkdocs-section-index mkdocs-toc-sidebar-plugin
+                mkdocs-section-index mkdocs-toc-sidebar-plugin mike
       - run: cd docs && mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -12,5 +12,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-awesome-pages-plugin \
+                mkdocs-section-index mkdocs-toc-sidebar-plugin
       - run: cd docs && mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 FreeTAKServer documentation for end users
 
 https://freetakteam.github.io/FreeTAKServer-User-Docs/
+
+## Notes for documentation updates
+
+The documentation now uses the `awesome-pages` plugin which allows a
+finer control of the document navigation. The official documentation for
+`awesome-pages` is located in the [project repo](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin)
+
+In short, one may create a `.pages` file with in the directory hierarchy
+to manipulate how the navigation structure is created. This file should
+contain the `nav:` structure for just that directory. If the `.pages`
+file does not exist then `mkdocs` will generate the navigate according
+to its internal rules.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,8 +1,24 @@
 site_name: FreeTAKServer Documentation
 repo_url: https://github.com/FreeTAKTeam/FreeTAKServer-User-Docs
 edit_uri: edit/main/docs/docs/
-sit_author: FreeTAKTeam
+site_author: FreeTAKTeam
+copyright: Copyright (c)2022 FreeTAKTeam
 theme:
-  'material'
+  name: 'material'
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.indexes
+    - navigation.sections
+    - toc.follow
+
 plugins:
   - search
+  - awesome-pages
+  - mike
+  - section-index
+
+extra:
+  version:
+    provider: mike


### PR DESCRIPTION
These changes adds a couple of `mkdocs` plugins to improve the documentation architecture and prepare for multiple versions of documentation. 

The added plugins are: 

- Awesome Pages
- Section Index
- TOC Sidebar
- Mike

The following is an image of the documentation being generated with the new plugins. This is slightly different than what the existing document will generate as. I had created a `.pages` file to test out how the Awesome Pages can control now the pages are structured. So the left sidebar is different than what would be generated without the `.pages` file. 

![image](https://user-images.githubusercontent.com/39609/200198555-6d51ec56-1492-41ba-ba7f-2a29ead131c3.png)

One of the reasons for incorporating the Awesome Pages plugin is so that the documentation can be restructured and presented in a more logical framework rather than spend the time reauthoring the existing documentation. In some cases this might be minor changes of just moving pages around and and other cases this may be a complete restructuring of an entire section as the way we (developers) consume/construct the docs may be different than the way that it should be presented to the public. 

Another basic change to the documentation is to have the major section in a "menu" bar across the top of the page and the left sidebar is just focused on that section. This alleviates having the left side bar filled up with all the sections and cluttering the sidebar. It should be noted that the sub-sections are now bolded to enhance the navigation of the section. The bolded sub-section can be configured to have a page attached to it or just be used to introduce the sub-pages. 

The Mike plugin is still being investigated to understand how it operates. Its purpose is to provide multiple versions of documentation. This will be especially useful as new versions of FTS are released. My belief is that it uses Git tags to mark points in the documentation to "snapshot" and then makes this available as a drop down menu at the top so that a user can change to the documentation for a specific code release. This will really be important as the FTS 2.0 code is released. 