### PR TITLE
docs: Update docker user and group id 

### DIFF
--- a/docs/docs/Installation/Docker/Quick_Start.md
+++ b/docs/docs/Installation/Docker/Quick_Start.md
@@ -68,4 +68,5 @@ From this point, please follow the Linux installation guide for information rega
 ## Persistent Data
 
 All persistent data is stored to /data and may be volume mounted.
-The host volume needs to be owned by user and group 1000.
+The `freetak` user is created by our Dockerfile, and is uid & gid `999`. There is no runtime configuration of user or group id.
+The host volume needs to be owned by user and group 999.


### PR DESCRIPTION
The docs currently say that the `freetak` user inside the container is uid/gid 1000, which is incorrect.

I'm suggesting this change to the docs while I work on making it possible to dynamically change the uid:gid using docker/docker-compose `--user/user:` functionality.

image digest information:
```
docker images --digests| grep freetakserver
ghcr.io/freetakteam/freetakserver            latest                          sha256:8ad7e36eaa0d70cd6ebeb14ad39f15dc6e4b9baa9af37ac77a809b54e35d5521   e28de6e9ca76   7 weeks ago     1.24GB
```

checks from the container itself:
```
docker run -it ghcr.io/freetakteam/freetakserver:latest sh -c '/usr/bin/id -u; /usr/bin/id -g; grep freetak /etc/passwd; grep freetak /etc/group'
999
999
freetak:x:999:999::/home/freetak:/bin/sh
freetak:x:999:
```